### PR TITLE
Fix parsing of recoverable malformed datatypes

### DIFF
--- a/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb/PdbDataTypeParser.java
+++ b/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb/PdbDataTypeParser.java
@@ -184,6 +184,17 @@ class PdbDataTypeParser {
 
 		String dataTypeName = datatype;
 
+		// Handle potential malformed datatypes where some datatype is implied
+		// *
+		// **
+		// [16]
+		if (dataTypeName.startsWith("*") || dataTypeName.startsWith("[")) {
+			// prepend undefined since intent is some datatype
+			Msg.warn(this, "dataTypeName \"" + dataTypeName + 
+				"\" references a pointer or array without a declared datatype; assuming undefined");
+			dataTypeName = "undefined" + dataTypeName;
+		}
+
 		// Example type representations:
 		// char *[2][3]     pointer(array(array(char,3),2))
 		// char *[2][3] *   pointer(array(array(pointer(char),3),2))


### PR DESCRIPTION
MSVC sometimes generates pdbs where there is an implied datatype such as pointers `*` or arrays `[16]`. While the actual datatype is unknown, Ghidra has undefined to cover this use case.

This avoids an error on PDB import which would have a cryptic message: "Symbol list must contain at least one symbol name!" without any info on what caused the issue.